### PR TITLE
Bugfix: Login error- 404 is truthy

### DIFF
--- a/assets/js/public/homepage/HomepageController.js
+++ b/assets/js/public/homepage/HomepageController.js
@@ -23,7 +23,7 @@ angular.module('HomepageModule').controller('HomepageController', ['$scope', '$h
 
       // Handle known error type(s).
       // Invalid username / password combination.
-      if (sailsResponse.status === 400 || 404) {
+      if (sailsResponse.status === 400 || sailsResponse.status === 404) {
         // $scope.loginForm.topLevelErrorMessage = 'Invalid email/password combination.';
         //
         toastr.error('Invalid email/password combination.', 'Error', {

--- a/assets/js/public/signup/SignupController.js
+++ b/assets/js/public/signup/SignupController.js
@@ -55,7 +55,7 @@ angular.module('SignupModule').controller('SignupController', ['$scope', '$http'
 
       // Handle known error type(s).
       // Invalid username / password combination.
-      if (sailsResponse.status === 400 || 404) {
+      if (sailsResponse.status === 400 || sailsResponse.status === 404) {
         // $scope.loginForm.topLevelErrorMessage = 'Invalid email/password combination.';
         //
         toastr.error('Invalid email/password combination.', 'Error', {


### PR DESCRIPTION
Problem: When there is a login error, the expected error is always true

Solution: compare: sailsResponse.status === 404
