### PR TITLE
Bugfix: logout user that no longer exists

### DIFF
--- a/api/controllers/UserController.js
+++ b/api/controllers/UserController.js
@@ -129,7 +129,6 @@ module.exports = {
       // If session refers to a user who no longer exists, still allow logout.
       if (!user) {
         sails.log.verbose('Session refers to a user who no longer exists.');
-        return res.backToHomePage();
       }
 
       // Wipe out the session (log out)


### PR DESCRIPTION
Fix the bug in which a user that doesn't exist will never log out (unless browser is closed, of course)
